### PR TITLE
Fix: Mixed content

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
   <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
   <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
-  <script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+  <script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
 
 {% if site.google_analytics and jekyll.environment == 'production' %}
 {% include analytics.html %}


### PR DESCRIPTION
The problem is that, when entering the page, you won't be able to see the math rendered properly. The issue is that the link for mathjax is using `HTTP` while the site is served over `HTTPS`.  
To fix the issue one should use `HTTPS` resources for its active resources (like scripts).

console log for the error
```
Mixed Content: The page at 'https://jrmeyer.github.io/machinelearning/2017/08/18/mle.html' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'. This request has been blocked; the content must be served over HTTPS.
```