### PR TITLE
Remove Coqui STT promotional notes from blog posts

### DIFF
--- a/_posts/2016-01-08-Installing-CMU-Sphinx-on-Ubuntu.markdown
+++ b/_posts/2016-01-08-Installing-CMU-Sphinx-on-Ubuntu.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/installation/2016/01/09/Installing-CMU-Sphinx-on-Ubuntu.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since CMU-Sphinx. Before devoting significant time to deploying CMU-Sphinx, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with speech technologies like CMU-Sphinx, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches and streamlined for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/sphinx.jpg" align="right" alt="logo" style="width: 300px;"/>
 
 ## Some Background
@@ -1021,6 +1009,3 @@ Total time: 7.001 secs
 [stackoverflow]: http://stackoverflow.com/questions/10630747/converting-the-lm-to-dmp-file-for-building-the-language-model-for-speech-rec
 [pocketsphinx]: https://github.com/cmusphinx/pocketsphinx
 [linux-manual]: http://man7.org/linux/man-pages/man8/ldconfig.8.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2016-01-26-CMU-Sphinx-Cheatsheet.markdown
+++ b/_posts/2016-01-26-CMU-Sphinx-Cheatsheet.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/cmusphinx/2016/01/26/CMU-Sphinx-Cheatsheet.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since CMU-Sphinx. Before devoting significant time to deploying CMU-Sphinx, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with speech technologies like CMU-Sphinx, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches and streamlined for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/sphinx.jpg" align="right" alt="logo" style="width: 300px;"/>
 
 ## Overview
@@ -251,9 +239,3 @@ perl word_align.pl your_test.transcription predictions.hyp
 
 
 [libgtk]: http://packages.ubuntu.com/precise/libgtk2.0-dev
-
-
-
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2016-01-26-Installing-Kaldi.markdown
+++ b/_posts/2016-01-26-Installing-Kaldi.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/kaldi/2016/01/26/Installing-Kaldi.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 ## Installation via GitHub
@@ -897,6 +885,3 @@ Happy Kaldi-ing!
 [irstlm]: http://hlt-mt.fbk.eu/technologies/irstlm
 [official-repo]: https://github.com/kaldi-asr/kaldi
 [docs]: http://kaldi-asr.org/doc/
-[coqui-github]: https://github.com/coqui-ai/stt
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-gitter]: https://gitter.im/coqui-ai/STT

--- a/_posts/2016-02-26-Kaldi-notes.markdown
+++ b/_posts/2016-02-26-Kaldi-notes.markdown
@@ -6,18 +6,6 @@ categories: ASR
 comments: True
 redirect_from: "/kaldi/2016/02/01/Kaldi-notes.html"
 ---
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 ## Documentation
@@ -429,6 +417,3 @@ Another [tutorial][tutorial2].
 [tutorial1]: http://m.mr-pc.org/work/jsalt2015lab.pdf
 [tutorial2]: http://pages.jh.edu/~echodro1/tutorial/kaldi/kaldi-intro.html
 [kaldi-for-dummies]: http://www.dsp.agh.edu.pl/_media/pl:dydaktyka:kaldi_for_dummies.pdf
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2016-09-12-Using-built-GMM-model-Kaldi.markdown
+++ b/_posts/2016-09-12-Using-built-GMM-model-Kaldi.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/kaldi/2016/09/12/Using-built-GMM-model-Kaldi.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 This post is essentially a walk through of [this shell script]({{ site.url }}/misc/gmm-decode.sh).
@@ -223,6 +211,3 @@ If you have any feedback or questions, don't hesitate to leave a comment!
 
 [kaldi-install]: http://jrmeyer.github.io/kaldi/2016/01/26/Installing-Kaldi.html
 [kaldi-notes]: http://jrmeyer.github.io/kaldi/2016/02/01/Kaldi-notes.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2016-12-15-DNN-AM-Kaldi.markdown
+++ b/_posts/2016-12-15-DNN-AM-Kaldi.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/kaldi/2016/12/15/DNN-AM-Kaldi.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 If you want to take a step back and learn about Kaldi in general, I have posts on [how to install Kaldi][kaldi-install] or some [miscellaneous Kaldi notes][kaldi-notes] which contain some documentation.
 
 All the scripts presented in this post or required for training can be downloaded [here]({{ site.url }}/misc/nnet2_simple.tar.gz) or cloned from here:
@@ -923,6 +911,3 @@ Co-authors include Dan Jurafsky and Andrew Ng, among others. This is a longer pa
 [rath-2013]: http://www.danielpovey.com/files/2013_interspeech_nnet_lda.pdf
 [povey-2015]: https://arxiv.org/pdf/1410.7455v4.pdf
 [nnet2-docs]: http://kaldi-asr.org/doc/dnn2.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2016-12-15-Visualize-lattice-kaldi.markdown
+++ b/_posts/2016-12-15-Visualize-lattice-kaldi.markdown
@@ -8,18 +8,6 @@ redirect_from: "/kaldi/2016/12/15/Visualize-lattice-kaldi.html"
 ---
 
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 ## Introduction

--- a/_posts/2017-01-10-Using-built-DNN-model-Kaldi.markdown
+++ b/_posts/2017-01-10-Using-built-DNN-model-Kaldi.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: "/kaldi/2017/01/10/Using-built-DNN-model-Kaldi.html"
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 ## Introduction
@@ -300,6 +288,3 @@ If you have any feedback or questions, don't hesitate to leave a comment!
 
 [kaldi-install]: http://jrmeyer.github.io/kaldi/2016/01/26/Installing-Kaldi.html
 [kaldi-notes]: http://jrmeyer.github.io/kaldi/2016/02/01/Kaldi-notes.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2017-10-13-Kaldi-AWS.markdown
+++ b/_posts/2017-10-13-Kaldi-AWS.markdown
@@ -7,18 +7,6 @@ comments: True
 redirect_from: /kaldi/2017/10/13/Kaldi-AWS.html
 ---
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="left" style="height: 95px"/>
 <img src="/misc/right-arrow.svg" align="middle" style="height: 80px"/>
 <img src="/misc/aws-logo.svg" align="right" style="height: 90px"/>
@@ -274,6 +262,3 @@ Happy Kaldi-ing!
 [ebs]: https://www.youtube.com/watch?v=DKftR47Ljvw
 [ec2]: https://www.youtube.com/watch?v=Px7ZPLq4AOU
 [install-cuda]: https://askubuntu.com/questions/799184/how-can-i-install-cuda-on-ubuntu-16-04
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2017-11-09-nnet3-notes.markdown
+++ b/_posts/2017-11-09-nnet3-notes.markdown
@@ -6,18 +6,6 @@ categories: ASR
 comments: True
 redirect_from: "/kaldi/2017/11/09/nnet3-notes.html"
 ---
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" alt="logo" style="width: 300px;"/>
 
 ## Introduction

--- a/_posts/2019-08-17-Kaldi-cheatsheet.markdown
+++ b/_posts/2019-08-17-Kaldi-cheatsheet.markdown
@@ -5,18 +5,6 @@ date:   2019-08-17
 categories: ASR
 comments: True
 ---
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi_text_and_logo.png" align="right" style="width: 300px;"/>
 
 ## Introduction
@@ -119,6 +107,3 @@ Let me know if you have comments or suggestions and you can always leave a comme
 [wsj]: https://github.com/kaldi-asr/kaldi/blob/master/egs/wsj/s5/run.sh
 [ctm]: https://github.com/kaldi-asr/kaldi/blob/master/egs/wsj/s5/steps/get_train_ctm.sh
 [troubleshooting]: http://jrmeyer.github.io/asr/2019/08/17/Kaldi-troubleshooting.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt

--- a/_posts/2019-08-17-Kaldi-troubleshooting.markdown
+++ b/_posts/2019-08-17-Kaldi-troubleshooting.markdown
@@ -7,18 +7,6 @@ comments: True
 ---
 
 
-<br/>
-<br/>
-
-> 👋 Hi, it's Josh here. I'm writing you this note in 2021: the world of speech technology has changed dramatically since Kaldi. Before devoting weeks of your time to deploying Kaldi, take a look at 🐸 [Coqui Speech-to-Text][coqui-github]. It takes minutes to deploy an off-the-shelf 🐸 STT model, and it's [open source on Github][coqui-github]. I'm on the Coqui founding team so I'm admittedly biased. However, you can tell from this blog that I've spent years working with Kaldi, so I understand the headaches.
->
-> With 🐸 STT, we've removed the headaches of Kaldi and streamlined everything for production settings. You can train and deploy state-of-the-art 🐸 Speech-to-Text models in just minutes, not weeks. Check out the [🐸 Model Zoo][coqui-model-zoo] for open, pre-trained models in different languages. Try it out for yourself, and come join our [friendly chatroom][coqui-gitter] 💚
-
-<br/>
-<br/>
-<br/>
-<br/>
-
 <img src="/misc/kaldi-troubleshooting.png" align="right" style="width: 300px;"/>
 
 ## Introduction
@@ -518,6 +506,3 @@ Let me know if you have comments or suggestions and you can always leave a comme
 [wsj]: https://github.com/kaldi-asr/kaldi/blob/master/egs/wsj/s5/run.sh
 [ctm]: https://github.com/kaldi-asr/kaldi/blob/master/egs/wsj/s5/steps/get_train_ctm.sh
 [cheatsheet]: http://jrmeyer.github.io/asr/2019/08/17/Kaldi-cheatsheet.html
-[coqui-gitter]: https://gitter.im/coqui-ai/STT
-[coqui-model-zoo]: https://coqui.ai/models
-[coqui-github]: https://github.com/coqui-ai/stt


### PR DESCRIPTION
Remove the 2021 promotional notes about Coqui Speech-to-Text from 12 blog posts about Kaldi and CMU-Sphinx. Also remove the associated link references at the end of each file.