### PR TITLE
Exclude CLAUDE.md from Jekyll build

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,3 +24,7 @@ google_analytics: UA-90329904-1
 
 plugins:
   - jekyll-redirect-from
+
+# Exclude files from build
+exclude:
+  - CLAUDE.md


### PR DESCRIPTION
The CLAUDE.md file was being rendered and displayed in site navigation. Adding it to the exclude list prevents Jekyll from processing it while keeping the file available for AI assistants in the repository.