### PR TITLE
Fix mobile image distortion on homepage by removing fixed height attributes

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,7 +12,7 @@ layout: default
 
 <div class="home">
 
-  <center><img src="misc/Lfst-big.png" height="500"></center>
+  <center><img src="misc/Lfst-big.png" style="max-width: 100%; height: auto;"></center>
 <br/>
 <br/>
 
@@ -34,7 +34,7 @@ layout: default
 <br/>
 
   <center>
-    <img src="misc/spectrogram.png" height="300" style="margin:15px; padding:15px;" >
+    <img src="misc/spectrogram.png" style="max-width: 100%; height: auto; margin:15px; padding:15px;" >
   </center>
 
     <h1 class="page-heading" style="font-size:40px;" >Speech Synthesis</h1>
@@ -55,7 +55,7 @@ layout: default
 <br/>
 
   <center>
-  <img src="misc/tf-graph.png" height="350" style="margin:35px; padding:15px;" >
+  <img src="misc/tf-graph.png" style="max-width: 100%; height: auto; margin:35px; padding:15px;" >
   </center>
 
     <h1 class="page-heading" style="font-size:40px;" >Machine Learning</h1>
@@ -76,7 +76,7 @@ layout: default
 <br/>
 
   <center>
-    <img src="/misc/figs/wet-on-wet.png" height="300" style="margin:15px; padding:15px;" >
+    <img src="/misc/figs/wet-on-wet.png" style="max-width: 100%; height: auto; margin:15px; padding:15px;" >
   </center>
 
   <h1 class="page-heading" style="font-size:40px;" >Miscellaneous</h1>


### PR DESCRIPTION
The homepage images had fixed HTML height attributes which, combined with
the CSS max-width: 100% rule, caused aspect ratio distortion on narrow
mobile viewports. Replaced with max-width/height:auto for proper scaling.

https://claude.ai/code/session_01AahKMYE5Evac8fApoGkoi9