### PR TITLE
Remove social share buttons and Facebook SDK to fix slow page loads

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -18,16 +18,6 @@
 
   <link rel="stylesheet" type="text/css" href="{{ "/css/asciinema-player.css" | prepend: site.baseurl }}" />
 
-  <!--facebook button code-->
-  <div id="fb-root"></div>
-<script>(function(d, s, id) {
-  var js, fjs = d.getElementsByTagName(s)[0];
-  if (d.getElementById(id)) return;
-  js = d.createElement(s); js.id = id;
-  js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.8";
-  fjs.parentNode.insertBefore(js, fjs);
-  }(document, 'script', 'facebook-jssdk'));</script>
-
 </head>
 
 

--- a/_includes/share-page.html
+++ b/_includes/share-page.html
@@ -1,9 +1,0 @@
-<div class="share-page" align="center" style="width:150px; margin:auto">
-    <br/>
-    
-    <div class="twitter-share-button" data-layout="button" data-mobile-iframe="true"><a href="https://twitter.com/share" class="twitter-share-button" data-show-count="false">Tweet</a><script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script></div>
-    
-  <div class="fb-share-button" data-href="https://developers.facebook.com/docs/plugins/" data-layout="button" data-mobile-iframe="true"><a class="fb-xfbml-parse-ignore" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u=https%3A%2F%2Fdevelopers.facebook.com%2Fdocs%2Fplugins%2F&amp;src=sdkpreparse">Share</a></div>
-  
-</div>
-

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,7 +6,6 @@
   <body>
 
     {% include header.html %}
-    {% include share-page.html %}
 
     <div class="page-content">
       <div class="wrapper">


### PR DESCRIPTION
Delete _includes/share-page.html (Twitter widgets.js + Facebook share button),
remove the Facebook SDK script from _includes/head.html, and remove the
share-page.html include from _layouts/default.html. These heavyweight
third-party scripts were loading on every page and blocking render.

https://claude.ai/code/session_0186j8fcmjDCvbaqGfje61k2