### PR TITLE
Fix mobile responsiveness for embedded media and floated images

### DIFF
--- a/_posts/2019-09-14-INTERSPEECH-schedule.markdown
+++ b/_posts/2019-09-14-INTERSPEECH-schedule.markdown
@@ -19,7 +19,7 @@ Last, I took a last pass over the sessions and put stars next to the sessions I 
 
 # Sunday
 
-<object data="/misc/1.pdf" type="application/pdf" width="700px" height="700px">
+<object data="/misc/1.pdf" type="application/pdf" width="100%" height="700px" style="max-width: 700px;">
     <embed src="/misc/1.pdf">
         <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/misc/1.pdf">Download PDF</a>.</p>
     </embed>
@@ -31,7 +31,7 @@ Last, I took a last pass over the sessions and put stars next to the sessions I 
 
 # Monday
 
-<object data="/misc/2.pdf" type="application/pdf" width="700px" height="700px">
+<object data="/misc/2.pdf" type="application/pdf" width="100%" height="700px" style="max-width: 700px;">
     <embed src="/misc/2.pdf">
         <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/misc/2.pdf">Download PDF</a>.</p>
     </embed>
@@ -44,7 +44,7 @@ Last, I took a last pass over the sessions and put stars next to the sessions I 
 
 # Tuesday
 
-<object data="/misc/3.pdf" type="application/pdf" width="700px" height="700px">
+<object data="/misc/3.pdf" type="application/pdf" width="100%" height="700px" style="max-width: 700px;">
     <embed src="/misc/3.pdf">
         <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/misc/3.pdf">Download PDF</a>.</p>
     </embed>
@@ -57,7 +57,7 @@ Last, I took a last pass over the sessions and put stars next to the sessions I 
 
 # Wednesday
 
-<object data="/misc/4.pdf" type="application/pdf" width="700px" height="700px">
+<object data="/misc/4.pdf" type="application/pdf" width="100%" height="700px" style="max-width: 700px;">
     <embed src="/misc/4.pdf">
         <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/misc/4.pdf">Download PDF</a>.</p>
     </embed>
@@ -70,7 +70,7 @@ Last, I took a last pass over the sessions and put stars next to the sessions I 
 
 # Thursday
 
-<object data="/misc/5.pdf" type="application/pdf" width="700px" height="700px">
+<object data="/misc/5.pdf" type="application/pdf" width="100%" height="700px" style="max-width: 700px;">
     <embed src="/misc/5.pdf">
         <p>This browser does not support PDFs. Please download the PDF to view it: <a href="/misc/5.pdf">Download PDF</a>.</p>
     </embed>

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -40,11 +40,28 @@ ul, ol, dl, figure,
 
 
 /**
- * Images
+ * Images and embedded media
  */
 img {
     max-width: 100%;
     vertical-align: middle;
+}
+
+img, iframe, object, embed {
+    max-width: 100% !important;
+    height: auto !important;
+}
+
+@include media-query($on-palm) {
+    img[align] {
+        float: none !important;
+        display: block !important;
+        margin: 0 auto !important;
+    }
+}
+
+div[style*="display: flex"] {
+    flex-wrap: wrap;
 }
 
 

--- a/about.md
+++ b/about.md
@@ -56,7 +56,9 @@ I also like travelling and Radiohead.
 
 
 <center>
-<iframe width="560" height="315" src="https://www.youtube.com/embed/V6G0tjT6A3I" frameborder="0" allowfullscreen></iframe>
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 560px; width: 100%; margin: 0 auto;">
+<iframe style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;" src="https://www.youtube.com/embed/V6G0tjT6A3I" frameborder="0" allowfullscreen></iframe>
+</div>
 </center>
 
 


### PR DESCRIPTION
Add global CSS rules in _base.scss to constrain img/iframe/object/embed
to max-width: 100% with !important to override inline styles. Add mobile
media query to neutralize align="right"/"left" floated images on small
screens. Wrap YouTube iframe in about.md in responsive aspect-ratio
container. Make PDF embeds in INTERSPEECH post use percentage width.
Add flex-wrap to inline flex containers via attribute selector.

https://claude.ai/code/session_017SNz9GpQhdQ4HaS14CiteP