### PR TITLE
Fix mobile equation overflow in word embeddings post

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -142,6 +142,16 @@ blockquote {
 
 
 /**
+ * MathJax equations - allow horizontal scroll on mobile
+ */
+.MathJax_Display {
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+}
+
+
+/**
  * Code formatting
  */
 pre,


### PR DESCRIPTION
Add horizontal scrolling to MathJax display equations so long
formulas (like hitRate) don't overflow on narrow mobile screens.

https://claude.ai/code/session_01Fv1CtPskkSHNR6HJyVem3o